### PR TITLE
Dockerize MISP feed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12.0-alpine
+
+WORKDIR /src
+
+COPY requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
+
+COPY /src .
+
+COPY crontab crontab
+
+RUN crontab crontab
+
+CMD ["crond", "&&", "tail", "-f", "/logfile"]

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ When done, the install script prints out instructions for running and starting *
 You can also find the instructions for setting up a MISP feed in the [docs](./docs/misp-feeds.md).
 
 For a more detailed description on how to configure **vmray-misp-feed**, see [vmray-misp-feed](./docs/vmray-misp-feed.md)
+
+### Using Docker
+
+You can also run and host the MISP feed using Docker. Therefor you'll first need to create a configuration:
+
+```
+cp config.toml.template config.toml
+```
+
+After that you can use the `compose.yml` and `docker compose up -d` to start and server the feed.
+You can use the `crontab` file to change the frequency of the execution.
+Make sure that the feed path from the config matches the compose file volume mappings.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,13 @@
+services:
+  feed:
+    build: .
+    volumes:
+      - ./config.toml:/config.toml
+      - ./vmray-misp-feed:/var/www/MISP/app/tmp/vmray-misp-feed
+  feed-server:
+    image: nginx
+    ports:
+      - 80:80
+    volumes:
+      - ./nginx:/etc/nginx/conf.d
+      - ./vmray-misp-feed:/var/www/feed

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+* * * * * python /src/feed.py >> /logfile

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,5 @@
+server {
+  listen 80;
+  server_name localhost;
+  root /var/www/feed;
+}


### PR DESCRIPTION
Hi,

I was trying to deploy the VMRay with and thought it would be a nice addition to this repo.
I've created a compose file which creates to containers, one for the feed and one for the static file server.
They share a volume which contains the feed content.
Let me know what you think.